### PR TITLE
Obscure sensible values on .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 APP_ENV=local
-APP_DEBUG=true
+APP_DEBUG=false
 APP_KEY=SomeRandomString
 
 DATABASE_URL=pgsql://call-tracking:call-tracking@localhost:5432/call-tracking


### PR DESCRIPTION
Avoids exposing sensible variables on production.

Changes in the PR:

- Add APP_DEBUG to false


Not possible due to the Laravel version:

- debug_blacklist to avoid exposing sensible variables even when debug is true. It was added in Laravel 5.5.13, and project version is Laravel 5.1